### PR TITLE
assetPaths を指定できるように

### DIFF
--- a/src/client/preview/render.ts
+++ b/src/client/preview/render.ts
@@ -48,6 +48,7 @@ export default function renderMain({ unboundStoryFn, storyContext, kind, name, s
         // FIXME: type error of `Property 'game' does not exist on type typeof g`.
         game: (g as any).game,
         assetIds: parameters.akashic.assetIds ?? [],
+        assetPaths: parameters.akashic.assetPaths ?? [],
       });
       scene.onLoad.addOnce(function () {
         render({ unboundStoryFn, storyContext, kind, name, scene });

--- a/src/client/preview/types.ts
+++ b/src/client/preview/types.ts
@@ -17,6 +17,7 @@ export type RenderArgs = {
 export type StorybookAkashicParameters<DefaultParameters extends {} = Parameters> = DefaultParameters & {
   akashic: {
     assetIds?: (string | g.DynamicAssetConfiguration)[];
+    assetPaths?: string[];
     configuration?: Partial<StorybookAkashicConfiguration>;
   };
 };


### PR DESCRIPTION
アセットの指定オプションに AkashicEngine v3 から利用できる `assetPaths` を追加しました。

- [複数アセットをまとめて扱う](https://akashic-games.github.io/tutorial/v3/assetPaths.html)
- [assetPaths](https://akashic-games.github.io/reference/akashic-engine-v3/interfaces/sceneparameterobject.html#assetpaths)
